### PR TITLE
Refactor for running in docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+
+node_modules
+.gitignore
+Changes
+Dockerfile
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-config/epp-config.json
+config/*.json
 *.log
 *.pem
 *.pem.asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:latest
 MAINTAINER Travis Holton <wtholton at gmail dot com>
 
-WORKDIR /opt/project
-ADD package.json /opt/project/
-
-RUN npm install
-
 WORKDIR /opt/project/node-epp
-ADD . /opt/project/node-epp
+COPY . /opt/project/node-epp
+RUN npm i
+
+EXPOSE 3000
+
+CMD ["npm", "test"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ registry, and then does the whole thing in reverse with the response.
 
 There are two separate server scripts:
 
-1. `lib/node-epp-server.js` is designed to function as a RESTful interface where you can
+1. `lib/node-epp-server.js` is designed to function as a web interface where you can
    POST and receive json requests.
 2. `lib/rabbit-epp.js`, runs as an RPC server that accepts requests via RabbitMQ.
 
@@ -35,7 +35,7 @@ this:
 
 ```javascript
 {
-    "registries": {
+    "app-config": {
         "registry-test1": {
           // registry1 data
         },
@@ -71,7 +71,7 @@ testing if you need to simulate transferring domains between two separate
 registrars.
 
 
-The `whitelisted_ips` tells the REST application to only accept certain hosts.
+The `whitelisted_ips` tells the  application to only accept certain hosts.
 
 
 
@@ -87,7 +87,7 @@ accordingly. They also assume that you have an online testing environment
 
 ## Running the web service
 
-The REST app is based on express.js and listens for POST requests on port 3000. The general URL scheme is as follows:
+The webservice app is based on express.js and listens for POST requests on port 3000. The general URL scheme is as follows:
     
     http://<host>:3000/command/<registry>/<command>
     
@@ -99,14 +99,15 @@ So to run a *checkDomain* for *registry1* on a local instance of the server, POS
 
 You can start it as follows:
 
-    node lib/node-epp-server.js -r registry1 -r registry2
+    node ./lib/node-epp-server.js -f my-config.json -r registrar1  [-j] [--loglevel debug] 
 
-The `-r` option specifies which registries the script should log into and can be used multiple times. These should correspond to the `registries` listed in the configuration file. In this case, the client will log into into *registry1* and *registry2*. 
+The `-f` option specifies a file containing configuration for the registries
+you wish to connect to. See *Configuration* section.
 
 Alternatively you can start it as a daemon:
 
     foreverd start -o nodepp-stout.log -e nodepp-sterr.log lib/node-epp-server.js \
-        -r registry-test1 -r registry-test2 -r registry-test3
+        -f my-config.json
 
 This tells it to open connections to three different registries.
 

--- a/config/epp-config-example.json
+++ b/config/epp-config-example.json
@@ -1,5 +1,5 @@
 {
-    "registries": {
+    "app-config": {
         "registry-test1": {
             "ssl": true,
             "key": "<optional key file>",

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,7 +10,10 @@ nconf.env()
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true 
+      })
     ]
 });
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2,28 +2,17 @@ var tls = require('tls');
 var net = require('net');
 var fs = require('fs');
 var Q = require('q');
-var nconf = require('nconf');
 var moment = require('moment');
-var winston = require('winston');
 
-nconf.env()
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true 
-      })
-    ]
-});
-
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 function ProtocolConnection(config) {
     this.config = config;
     this.setStream(false);
 }
 
 ProtocolConnection.prototype.clientResponse = function(xml) {
-    logger.info("Received: " + xml.toString('utf8'))
+    logger.debug("Received: " + xml.toString('utf8'))
 };
 ProtocolConnection.prototype.setStream = function(newStream) {
     this.stream = newStream;
@@ -118,7 +107,7 @@ ProtocolConnection.prototype.send = function(xml) {
     };
     try {
         var preparedXML = this.processBigEndian(xml);
-        logger.info(xml);
+        logger.debug(xml);
         this.stream.write(preparedXML, "utf8", function() {
             logger.info("Finished writing to server.");
         });

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -1,20 +1,9 @@
 var ProtocolState = require('./protocol-state.js');
-var winston = require('winston');
-var nconf = require('nconf');
 var moment = require('moment');
 
-nconf.env().file({
-    "file": "./config/epp-config.json"
-});
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-      })
-    ]
-});
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
+
 
 function Dispatcher() {
 
@@ -53,7 +42,9 @@ Dispatcher.prototype.processMessage = function processMessage(m) {
         }
     } else { // Initialise a connection instance with registry configuration.
         var registry = m.registry;
-        var registryConfig = nconf.get('registries')[registry];
+        logger.info("Starting for registry: ", registry);
+        var registryConfig = nconf.get('app-config')[registry];
+        logger.info("Using config to contact registrar", registryConfig);
         currentState = new ProtocolState(registry, registryConfig);
         var loginTransactionId = ['login', new Date().getTime(), require('crypto').randomBytes(8).toString('hex')].join('-').toUpperCase();
 

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -9,7 +9,10 @@ nconf.env().file({
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+      })
     ]
 });
 

--- a/lib/epp-factory.js
+++ b/lib/epp-factory.js
@@ -4,18 +4,9 @@ var EPPExtension = require('../lib/epp-extension.js');
 var SecDnsExtension = require('../lib/secdns-extension.js');
 var HexonetExtension = require('../lib/hexonet-extension.js');
 var AfiliasExtension = require('../lib/afilias-extension.js');
-var nconf = require('nconf');
 
-nconf.env()
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-      })
-    ]
-});
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 /*
  *  Compose extension classes into the main EPP library as needed. As
  *  different registries have different extensions, and some, but not all may

--- a/lib/epp-factory.js
+++ b/lib/epp-factory.js
@@ -10,7 +10,10 @@ nconf.env()
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+      })
     ]
 });
 /*

--- a/lib/epp.js
+++ b/lib/epp.js
@@ -1,18 +1,6 @@
-var winston = require('winston');
-var nconf = require('nconf');
 
-nconf.env()
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-
-      })
-    ]
-});
-
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 var convert = require('data2xml')({
     'undefined': 'empty',
     'null': 'closed'

--- a/lib/epp.js
+++ b/lib/epp.js
@@ -5,7 +5,11 @@ nconf.env()
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+
+      })
     ]
 });
 

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -1,17 +1,6 @@
-var winston = require('winston');
-var nconf = require('nconf');
 
-nconf.env()
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-      })
-    ]
-});
-
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 var available;
 var busy;
 var childQueue = [];

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -5,7 +5,10 @@ nconf.env()
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+      })
     ]
 });
 

--- a/lib/node-epp-server.js
+++ b/lib/node-epp-server.js
@@ -1,44 +1,23 @@
 var express = require("express");
 var bodyParser = require("body-parser");
 var cp = require('child_process');
-var program = require('commander');
 var ipfilter =  require('ipfilter');
 var moment = require('moment');
 var Listener = require('./listener.js');
 var EventDispatcher = require('./event-dispatcher.js');
-var path = require('path');
-var nconf = require('nconf');
-var winston = require('winston');
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 
-nconf.env().file({
-    "file": path.resolve(__dirname, '..', 'config/epp-config.json')
-});
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level
-          "json": true
-      })
-    ]
-});
-
-function collectRegistries(val, registryArgs) {
-    registryArgs.push(val);
-    return registryArgs;
-}
-
-// Read command-line arguments.
-program.version('0.0.1').usage('[options]').option('-r, --registries <registry>', 'Registry', collectRegistries, []).option('-l, --listen <n>', 'Listen on port', parseInt, 3000);
-program.parse(process.argv);
-
-var registries = program.registries;
-logger.log("Initialised with registries: ", registries);
+logger.debug("Starting epp server.", process.argv);
 
 var availableProcesses = {};
+var appConfig = nconf.get('app-config');
+var registries = nconf.get('registries');
+logger.debug("Registries: ", registries);
 for (var accred in registries) {
     var registry = registries[accred];
-    var eppProcess = cp.fork(__dirname + '/worker.js');
+    logger.info("Starting worker for", registry);
+    var eppProcess = cp.fork(__dirname + '/worker.js', process.argv.slice(2));
     eppProcess.send({
         "registry": registry
     });
@@ -46,7 +25,7 @@ for (var accred in registries) {
 }
 process.on('SIGINT', function() {
     var logoutResponse = function(data) {
-        logger.log("Got reply from logout: ", data);
+        logger.info("Got reply from logout: ", data);
     };
     for (var registry in availableProcesses) {
         var childProc = availableProcesses[registry];
@@ -100,6 +79,5 @@ app.post('/command/:registry/:command', function(req, res) {
     listener.pushChildQueue(processChild);
     eventDispatch.queueChild(registry);
 });
-
-app.listen(program.listen);
+app.listen(nconf.get('listen'));
 

--- a/lib/node-epp-server.js
+++ b/lib/node-epp-server.js
@@ -16,7 +16,10 @@ nconf.env().file({
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level
+          "json": true
+      })
     ]
 });
 

--- a/lib/nodepp.js
+++ b/lib/nodepp.js
@@ -1,18 +1,7 @@
-var forever = require('forever-monitor'),
-    nconf = require('nconf');
-var winston = require('winston');
-var nconf = require('nconf');
-nconf.env();
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-      })
-    ]
-});
+var forever = require('forever-monitor');
 
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 logger.debug("Got environment: ", nconf.get('EPP_REGISTRIES'));
 
 var child = new(forever.Monitor)('./lib/server.js', {

--- a/lib/nodepp.js
+++ b/lib/nodepp.js
@@ -6,7 +6,10 @@ nconf.env();
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+      })
     ]
 });
 

--- a/lib/protocol-state.js
+++ b/lib/protocol-state.js
@@ -10,7 +10,10 @@ nconf.env()
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+      })
     ]
 });
 

--- a/lib/protocol-state.js
+++ b/lib/protocol-state.js
@@ -3,19 +3,9 @@ var ProtocolConnection = require('./connection.js');
 var parser = require('xml2json');
 var moment = require('moment');
 var Q = require('q');
-var winston = require('winston');
-var nconf = require('nconf');
 
-nconf.env()
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-      })
-    ]
-});
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 
 var currRegistry;
 function ProtocolState(registry, config) {
@@ -79,10 +69,11 @@ ProtocolState.prototype.processReturnedXML = function(returnedXML) {
     var response = parser.toJson(returnedXML, {
         "object": true
     });
-    logger.info(returnedXML.toString());
+    logger.debug(returnedXML.toString());
     var processedResponse = this.processResponse(response);
     if (processedResponse && processedResponse.result) {
         var result = processedResponse.result;
+        logger.info("Processed response", processedResponse);
         return processedResponse;
     }
 };
@@ -91,7 +82,6 @@ ProtocolState.prototype.login = function(data, transactionId) {
     var self = this;
 
     return this.command('login', data, transactionId).then(function(data) {
-        logger.debug("login returned data: ", data);
         var result = data.result;
 
         if (result.hasOwnProperty('code') && result.code < 2000) {

--- a/lib/rabbit-epp.js
+++ b/lib/rabbit-epp.js
@@ -14,7 +14,10 @@ nconf.env().file({
 var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
 var logger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: log_level })
+      new (winston.transports.Console)({ 
+          "level": log_level,
+          "json": true
+      })
     ]
 });
 

--- a/lib/rabbit-epp.js
+++ b/lib/rabbit-epp.js
@@ -4,22 +4,9 @@ var moment = require('moment');
 var AMQP = require('amqp-as-promised');
 var Q = require('q');
 var path = require('path');
-var nconf = require('nconf');
-var winston = require('winston');
 var processId = process.pid;
-nconf.env().file({
-    "file": path.resolve(__dirname, '..', 'config/epp-config.json')
-});
-
-var log_level = (nconf.get('LOG_LEVEL') || 'debug').toLowerCase();
-var logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({ 
-          "level": log_level,
-          "json": true
-      })
-    ]
-});
+var nconf = require('./utilities/config.js').getConfig();
+var logger = require('./utilities/logging.js').getLogger(nconf);
 
 var rabbitmqConfig = nconf.get('rabbitmq');
 // Environment values override the config values if present.

--- a/lib/utilities/config.js
+++ b/lib/utilities/config.js
@@ -1,0 +1,39 @@
+var nconf = require('nconf');
+var path = require('path');
+var argv = require('yargs')
+    .option('app-config', {
+        "alias": "a",
+        "describe": "Configure EPP with JSON string",
+        "string": true
+    }).coerce('app-config', JSON.parse)
+    .option("registries", {
+        "alias": "r",
+        "describe": "List of domain registries",
+        "array": true
+    })
+    .option("listen",{
+        "alias": "l",
+        "describe": "listen",
+        "default": 3000,
+        "number": true
+    }).option( "json", {
+        "alias": "j",
+        "describe": "JSON formatted logs",
+        "default": false
+    }).option('config-file', {
+        "alias": "f",
+        "describe": "Path to JSON config file"
+    }).option('loglevel', {
+        "describe": "Log level",
+        "default": "info"
+    }).help('h').alias('h', 'help')
+    .argv;
+
+module.exports.getConfig = function(file) {
+    nconf.overrides(argv).env();
+    var defaultFile = 'epp-config.json';
+    file = nconf.get('config-file') || file || defaultFile;
+    var filePath = path.resolve(__dirname, '../../config', file);
+    nconf.file(filePath);
+    return nconf;
+};

--- a/lib/utilities/logging.js
+++ b/lib/utilities/logging.js
@@ -1,0 +1,19 @@
+var winston = require('winston');
+var moment = require('moment');
+
+module.exports.getLogger = function(nconf) {
+    var log_level = nconf.get('loglevel');
+    return new (winston.Logger)({
+        transports: [
+            new (winston.transports.Console)({ 
+                "level": log_level,
+                "json": nconf.get('json'),
+                "timestamp":  function() {
+                    return moment();
+                }
+            })
+        ]
+    });
+};
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-epp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "EPP client for domain registrars.",
   "main": "index.js",
   "bin": {
@@ -9,10 +9,11 @@
   },
   "scripts": {
     "test": "mocha test/*.js",
+    "start": "node-epp-rest",
     "checkVersion": "mocha --version"
   },
   "author": "Trav Holton",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "amqp": "*",
     "amqp-as-promised": "*",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "amqp": "*",
     "amqp-as-promised": "*",
     "body-parser": "*",
-    "commander": "*",
     "crypto": "*",
     "daemon": "*",
     "data2xml": "*",
@@ -34,6 +33,7 @@
     "q": "*",
     "uuid": "^3.0.0",
     "winston": "*",
+    "yargs": "*",
     "xml2json": "*"
   },
   "devDependencies": {

--- a/test/basic-rabbit.js
+++ b/test/basic-rabbit.js
@@ -1,14 +1,11 @@
+var nconf = require('../lib/utilities/config.js').getConfig();
+var logger = require('../lib/utilities/logging.js').getLogger(nconf);
 var Amqp = require('amqp-as-promised');
-nconf = require('nconf');
-var path = require('path');
-nconf.env().file({
-    "file": path.resolve(__dirname, '..', 'config/epp-config.json')
-});
 var uuid = require('uuid');
 var Q = require('q');
 var rabbitmqConfig = nconf.get('rabbitmq');
 var chai = require('chai');
-var expect = chai.expect,
+var expect = chai.expect;
 should = chai.should;
 
 describe.skip('RabbitMQ operation', function() {

--- a/test/epp-communication.js
+++ b/test/epp-communication.js
@@ -1,11 +1,8 @@
-nconf = require('nconf');
-var path = require('path');
-nconf.env().file({
-    "file": path.resolve(__dirname, '..', 'config/epp-config-example.json')
-});
 var fs = require('fs');
 var chai = require('chai');
 var moment = require('moment');
+var nconf = require('../lib/utilities/config.js').getConfig();
+var logger = require('../lib/utilities/logging.js').getLogger(nconf);
 
 var expect = chai.expect,
 should = chai.should;

--- a/test/epp-generate.js
+++ b/test/epp-generate.js
@@ -4,17 +4,14 @@ var expect = chai.expect,
 should = chai.should;
 
 var EppFactory = require('../lib/epp-factory.js');
-nconf = require('nconf');
-var path = require('path');
-nconf.env().file({
-    "file": path.resolve(__dirname, '..', 'config/epp-config-example.json')
-});
+var nconf = require('../lib/utilities/config.js').getConfig('epp-config-example.json');
+var logger = require('../lib/utilities/logging.js').getLogger(nconf);
 
 describe('EPP serialisation', function() {
     describe('general commands', function() {
         var epp, config;
         beforeEach(function() {
-            config = nconf.get('registries')['registry-test2'];
+            config = nconf.get('app-config')['registry-test2'];
             epp = EppFactory.generate('registry-test2', config);
             if (!epp) {
                 throw new Error("Unable to initialise epp");
@@ -555,7 +552,7 @@ describe('EPP serialisation', function() {
     describe('extension handling', function() {
         var epp, config;
         beforeEach(function() {
-            config = nconf.get('registries')['registry-test1'];
+            config = nconf.get('app-config')['registry-test1'];
             epp = EppFactory.generate('registry-test1', config);
         });
         it('should be decorated with the secDNS extension methods', function() {
@@ -772,7 +769,7 @@ describe('EPP serialisation', function() {
     describe('Hexonet extension', function() {
         var reg2Epp, config;
         beforeEach(function() {
-            config = nconf.get('registries')['registry-test2'];
+            config = nconf.get('app-config')['registry-test2'];
             reg2Epp = EppFactory.generate('registry-test2', config);
         });
         it('should be decorated with the secDNS extension methods', function() {


### PR DESCRIPTION
Making a number of changes to make it possible to run in a Docker container and a few other fixes:

* Refactored log and config to modules
* Add options to control 'log level' and output logs as JSON
* Add timestamp to logs
* Pass configuration parameters (mainly for logging) to worker process
* Change command line handling to allow passing registry config. Not really ideal or meant for production. Need to find more secure way to do this.