### PR TITLE
fix retrieving endian length

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -84,7 +84,7 @@ ProtocolConnection.prototype.readStream = function () {
             this.buffer = Buffer.concat([this.buffer, streamBuffer]);
         }
         var bigEndian = this.buffer.slice(0, 4);
-        var totalLength = new Buffer(bigEndian).readUIntBE(0);
+        var totalLength = new Buffer(bigEndian).readUIntBE(0, 4);
         var restOfBuffer = this.buffer.slice(4);
         var currentLength = this.buffer.length;
         logger.debug("endian length: ", totalLength);


### PR DESCRIPTION
The endian length was not being parsed properly so the length comparison check was failing. By specifying the byteLength to readUIntBE, it meant that the totalLength parameter was set properly.

Tested under node.js v7.3.0